### PR TITLE
Update gatsby-node.js to support newer version of webpack.

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -46,7 +46,7 @@ exports.onCreateWebpackConfig = ({
     })
   }
 
-  config.plugins.push(new webpack.WatchIgnorePlugin([/css\.d\.ts$/]))
+  config.plugins.push(new webpack.WatchIgnorePlugin({paths:[/css\.d\.ts$/]}))
 
   actions.replaceWebpackConfig(config)
 }


### PR DESCRIPTION
The newer versions of webpack WatchIgorePlugin have a different parameter that is send to it. Instead of sending just the array of paths, now it accepts object with the paths property. This change adjusts that.